### PR TITLE
Add karaoke web app

### DIFF
--- a/karaoke-webapp/README.md
+++ b/karaoke-webapp/README.md
@@ -1,0 +1,15 @@
+# Karaoke Web App
+
+Simple PHP web application to manage karaoke nights with queue management, user roles and voting.
+
+## Setup
+1. Import `setup.sql` in your MySQL server.
+2. Configure database credentials in `config.php`.
+3. Deploy the `karaoke-webapp` folder on your Apache server.
+
+## Features
+- User authentication with roles: admin, manager, client, judge.
+- Add songs with YouTube link or search via YouTube API.
+- Drag and drop queue reordering.
+- Public voting for performed songs.
+- Basic category management pre-filled in SQL file.

--- a/karaoke-webapp/admin.php
+++ b/karaoke-webapp/admin.php
@@ -1,0 +1,45 @@
+<?php
+require 'config.php';
+if ($_SESSION['role'] !== 'admin') {
+    header('Location: index.php');
+    exit;
+}
+
+if (isset($_POST['username'], $_POST['password'], $_POST['role'])) {
+    $hash = password_hash($_POST['password'], PASSWORD_DEFAULT);
+    $stmt = $mysqli->prepare('INSERT INTO users (username, password, role) VALUES (?,?,?)');
+    $stmt->bind_param('sss', $_POST['username'], $hash, $_POST['role']);
+    $stmt->execute();
+    $stmt->close();
+}
+
+$users = $mysqli->query('SELECT id, username, role FROM users');
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Admin</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>User Management</h1>
+    <form method="POST">
+        <input type="text" name="username" placeholder="Username" required>
+        <input type="password" name="password" placeholder="Password" required>
+        <select name="role">
+            <option value="admin">admin</option>
+            <option value="manager">gestore canzoni</option>
+            <option value="client">cliente</option>
+            <option value="judge">giudice</option>
+        </select>
+        <button type="submit">Add User</button>
+    </form>
+    <h2>Existing Users</h2>
+    <ul>
+        <?php while ($u = $users->fetch_assoc()): ?>
+            <li><?php echo htmlspecialchars($u['username']).' ('.$u['role'].')'; ?></li>
+        <?php endwhile; ?>
+    </ul>
+</body>
+</html>

--- a/karaoke-webapp/config.php
+++ b/karaoke-webapp/config.php
@@ -1,0 +1,14 @@
+<?php
+// Basic database connection using MySQLi
+$host = 'localhost';
+$user = 'karaoke_user';
+$password = 'karaoke_pass';
+$database = 'karaoke';
+
+$mysqli = new mysqli($host, $user, $password, $database);
+if ($mysqli->connect_errno) {
+    die('Failed to connect to MySQL: ' . $mysqli->connect_error);
+}
+
+session_start();
+?>

--- a/karaoke-webapp/create_song.php
+++ b/karaoke-webapp/create_song.php
@@ -1,0 +1,49 @@
+<?php
+require 'config.php';
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+if (isset($_POST['title'], $_POST['youtube_link'], $_POST['category_id'])) {
+    $stmt = $mysqli->prepare('INSERT INTO songs (title, youtube_link, category_id, added_by) VALUES (?,?,?,?)');
+    $stmt->bind_param('ssii', $_POST['title'], $_POST['youtube_link'], $_POST['category_id'], $_SESSION['user_id']);
+    $stmt->execute();
+    $songId = $stmt->insert_id;
+    $stmt->close();
+
+    $stmt = $mysqli->prepare('INSERT INTO queue (song_id, requester_id, position) VALUES (?,?, (SELECT IFNULL(MAX(position),0)+1 FROM queue))');
+    $stmt->bind_param('ii', $songId, $_SESSION['user_id']);
+    $stmt->execute();
+    $stmt->close();
+    header('Location: index.php');
+    exit;
+}
+
+$cats = $mysqli->query('SELECT id, name FROM categories');
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Add Song</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="youtube_search.js"></script>
+</head>
+<body>
+    <h1>Add Song</h1>
+    <form method="POST">
+        <input type="text" name="title" placeholder="Song Title" required><br>
+        <input type="text" name="youtube_link" id="youtube_link" placeholder="YouTube Link" required>
+        <button type="button" id="searchBtn">Search YouTube</button><br>
+        <select name="category_id" required>
+            <?php while ($c = $cats->fetch_assoc()): ?>
+                <option value="<?php echo $c['id']; ?>"><?php echo htmlspecialchars($c['name']); ?></option>
+            <?php endwhile; ?>
+        </select><br>
+        <button type="submit">Add</button>
+    </form>
+    <div id="results"></div>
+</body>
+</html>

--- a/karaoke-webapp/index.php
+++ b/karaoke-webapp/index.php
@@ -1,0 +1,44 @@
+<?php
+require 'config.php';
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+// handle reorder via AJAX
+if (isset($_POST['order'])) {
+    foreach ($_POST['order'] as $position => $reqId) {
+        $stmt = $mysqli->prepare('UPDATE queue SET position=? WHERE id=?');
+        $pos = $position + 1;
+        $stmt->bind_param('ii', $pos, $reqId);
+        $stmt->execute();
+    }
+    exit('ok');
+}
+
+$result = $mysqli->query("SELECT q.id, s.title, s.youtube_link, u.username FROM queue q JOIN songs s ON q.song_id = s.id JOIN users u ON q.requester_id = u.id ORDER BY q.position ASC");
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Karaoke Queue</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Welcome <?php echo htmlspecialchars($_SESSION['role']); ?></h1>
+    <a href="create_song.php">Add Song</a> | <a href="logout.php">Logout</a>
+    <h2>Queue</h2>
+    <ul id="queue">
+        <?php while ($row = $result->fetch_assoc()): ?>
+            <li data-id="<?php echo $row['id']; ?>">
+                <?php echo htmlspecialchars($row['title']); ?> - <?php echo htmlspecialchars($row['username']); ?>
+                [<a href="<?php echo htmlspecialchars($row['youtube_link']); ?>" target="_blank">YouTube</a>]
+            </li>
+        <?php endwhile; ?>
+    </ul>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/karaoke-webapp/login.php
+++ b/karaoke-webapp/login.php
@@ -1,0 +1,38 @@
+<?php
+require 'config.php';
+
+if (isset($_POST['username'], $_POST['password'])) {
+    $username = $_POST['username'];
+    $password = $_POST['password'];
+    $stmt = $mysqli->prepare('SELECT id, role, password FROM users WHERE username = ?');
+    $stmt->bind_param('s', $username);
+    $stmt->execute();
+    $stmt->bind_result($id, $role, $hash);
+    if ($stmt->fetch() && password_verify($password, $hash)) {
+        $_SESSION['user_id'] = $id;
+        $_SESSION['role'] = $role;
+        header('Location: index.php');
+        exit;
+    } else {
+        $error = 'Invalid credentials';
+    }
+    $stmt->close();
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Karaoke Login</h1>
+    <?php if (!empty($error)) echo '<p class="error">'.$error.'</p>'; ?>
+    <form method="POST">
+        <input type="text" name="username" placeholder="Username" required>
+        <input type="password" name="password" placeholder="Password" required>
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>

--- a/karaoke-webapp/logout.php
+++ b/karaoke-webapp/logout.php
@@ -1,0 +1,4 @@
+<?php
+require 'config.php';
+session_destroy();
+header('Location: login.php');

--- a/karaoke-webapp/script.js
+++ b/karaoke-webapp/script.js
@@ -1,0 +1,8 @@
+$(function() {
+  $('#queue').sortable({
+    update: function() {
+      var order = $(this).sortable('toArray', {attribute: 'data-id'});
+      $.post('index.php', {order: order});
+    }
+  });
+});

--- a/karaoke-webapp/setup.sql
+++ b/karaoke-webapp/setup.sql
@@ -1,0 +1,44 @@
+CREATE DATABASE IF NOT EXISTS karaoke CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE karaoke;
+
+CREATE TABLE users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  username VARCHAR(50) UNIQUE NOT NULL,
+  password VARCHAR(255) NOT NULL,
+  role ENUM('admin','manager','client','judge') NOT NULL
+);
+
+CREATE TABLE categories (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(50) NOT NULL
+);
+INSERT INTO categories (name) VALUES ('Singolo Maschile'),('Singolo Femminile'),('Doppio');
+
+CREATE TABLE songs (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  title VARCHAR(100) NOT NULL,
+  youtube_link VARCHAR(255) NOT NULL,
+  category_id INT,
+  added_by INT,
+  performed TINYINT(1) DEFAULT 0,
+  FOREIGN KEY (category_id) REFERENCES categories(id),
+  FOREIGN KEY (added_by) REFERENCES users(id)
+);
+
+CREATE TABLE queue (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  song_id INT NOT NULL,
+  requester_id INT NOT NULL,
+  position INT NOT NULL,
+  FOREIGN KEY (song_id) REFERENCES songs(id),
+  FOREIGN KEY (requester_id) REFERENCES users(id)
+);
+
+CREATE TABLE votes (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  song_id INT NOT NULL,
+  user_id INT NOT NULL,
+  score INT NOT NULL,
+  FOREIGN KEY (song_id) REFERENCES songs(id),
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);

--- a/karaoke-webapp/style.css
+++ b/karaoke-webapp/style.css
@@ -1,0 +1,4 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+ul { list-style: none; padding: 0; }
+li { padding: 8px; background: #eee; margin-bottom: 4px; cursor: move; }
+.error { color: red; }

--- a/karaoke-webapp/vote.php
+++ b/karaoke-webapp/vote.php
@@ -1,0 +1,36 @@
+<?php
+require 'config.php';
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+if (isset($_POST['song_id'], $_POST['score'])) {
+    $stmt = $mysqli->prepare('REPLACE INTO votes (song_id, user_id, score) VALUES (?,?,?)');
+    $stmt->bind_param('iii', $_POST['song_id'], $_SESSION['user_id'], $_POST['score']);
+    $stmt->execute();
+    $stmt->close();
+}
+
+$songs = $mysqli->query('SELECT id, title FROM songs WHERE performed = 1');
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Vote</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Vote</h1>
+    <form method="POST">
+        <select name="song_id">
+            <?php while ($s = $songs->fetch_assoc()): ?>
+                <option value="<?php echo $s['id']; ?>"><?php echo htmlspecialchars($s['title']); ?></option>
+            <?php endwhile; ?>
+        </select>
+        <input type="number" name="score" min="1" max="5" required>
+        <button type="submit">Submit Vote</button>
+    </form>
+</body>
+</html>

--- a/karaoke-webapp/youtube_search.js
+++ b/karaoke-webapp/youtube_search.js
@@ -1,0 +1,22 @@
+$(function(){
+  $('#searchBtn').click(function(){
+    var query = $('input[name="title"]').val();
+    if(!query) return;
+    $.get('https://www.googleapis.com/youtube/v3/search', {
+      part: 'snippet',
+      q: query,
+      maxResults: 5,
+      type: 'video',
+      key: 'YOUR_API_KEY'
+    }, function(res){
+      var results = $('#results').empty();
+      res.items.forEach(function(item){
+        var url = 'https://www.youtube.com/watch?v=' + item.id.videoId;
+        var btn = $('<button>Select</button>').click(function(){
+          $('#youtube_link').val(url);
+        });
+        results.append($('<div>').text(item.snippet.title).append(' ').append(btn));
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a lightweight PHP karaoke management web app
- include YouTube search integration, queue management and voting
- store the creation SQL file for the database

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a8b8f0d4c8333acea2f931160775c